### PR TITLE
fix command execution on windows

### DIFF
--- a/shared/src/utils.rs
+++ b/shared/src/utils.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::env;
 
 use crate::version::version_manifest::{VersionInfo, VersionManifest};
 


### PR DESCRIPTION
костыль помог мне исправить os error 123 на win10.

some explanation:
parts[0], parts[2] имеют префикс \?\ при генерации нового instances, что не позволяет выполнить команду, поэтому в данном коде этот префикс удален

просьба подправить функцию exec_custom_command_in_dir, потому что, очевидно, смотря на код, она будет плохо работать.

